### PR TITLE
add batch encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Simple FastAPI project that handles requests to google's Geocoding API.
 
 ## Usage
 
-Send `post` requests at `http://localhost:8000/encode` with a `location` argument. Example:
+Send `post` requests at `http://localhost:8000/encode` with a `locations` argument. Example:
 
 ```
 curl --location --request POST 'http://localhost:8000/encode' \
 --header 'Content-Type: application/json' \
 --data-raw '{
-    "location": "new york city"
+    "locations": ["new york city"]
 }'
 ```
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
 import os
 
 
-def load_envs() -> tuple[str, str]:
+def load_url_and_api_key() -> tuple[str, str]:
     url = os.getenv("GEOCODING_URL")
     api_key = os.getenv("GEOCODING_API_KEY")
     if not url or not api_key:

--- a/app/main.py
+++ b/app/main.py
@@ -1,18 +1,27 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.geocoding import GeocodingController
 
 app = FastAPI()
 geocoding_controller = GeocodingController()
 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 
 class GeocodeRequest(BaseModel):
-    location: str
+    locations: list[str]
 
 
-@app.post("/encode/")
+@app.post("/encode")
 async def encode(request_data: GeocodeRequest):
-    response = await geocoding_controller.get_coordinates(request_data.location)
+    response = await geocoding_controller.get_coordinates(request_data.locations)
 
     return {"results": response}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 
 services:
-  geocoding_api:
+  geocoding-api:
     build: .
     ports:
       - "8000:8000"


### PR DESCRIPTION
no-jira

Expected `locations` parameter is now a list of strings instead of a single string.