### PR TITLE
ITAI-3775 - Multiple names for each location as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,51 +9,146 @@ Simple FastAPI project that handles requests to google's Geocoding API.
 
 ## Usage
 
-Send `post` requests at `http://localhost:8000/encode` with a `locations` argument. Example:
+Send `post` requests at `http://localhost:8000/encode` with a `locations` argument.\
+Each location is a list of names/alternate names. Note that api returns geocoded location for **every** name. Example:
 
 ```
 curl --location --request POST 'http://localhost:8000/encode' \
 --header 'Content-Type: application/json' \
 --data-raw '{
-    "locations": ["new york city"]
+    "locations": [["włoszech", "włochy"], ["londynu", "londyn"]]
 }'
 ```
 
-response:
+Response:
 
 ```
 {
     "results": [
-        {
-            "formatted_address": "New York, NY, USA",
-            "geometry": {
-                "bounds": {
-                    "northeast": {
-                        "lat": 40.917705,
-                        "lng": -73.700169
+        [
+            {
+                "formatted_address": "Italy",
+                "geometry": {
+                    "bounds": {
+                        "northeast": {
+                            "lat": 47.092,
+                            "lng": 18.7975999
+                        },
+                        "southwest": {
+                            "lat": 35.4897,
+                            "lng": 6.6267201
+                        }
                     },
-                    "southwest": {
-                        "lat": 40.476578,
-                        "lng": -74.258843
+                    "location": {
+                        "lat": 41.87194,
+                        "lng": 12.56738
+                    },
+                    "location_type": "APPROXIMATE",
+                    "viewport": {
+                        "northeast": {
+                            "lat": 47.092,
+                            "lng": 18.7975999
+                        },
+                        "southwest": {
+                            "lat": 35.4897,
+                            "lng": 6.6267201
+                        }
                     }
-                },
-                "location": {
-                    "lat": 40.7127753,
-                    "lng": -74.0059728
-                },
-                "location_type": "APPROXIMATE",
-                "viewport": {
-                    "northeast": {
-                        "lat": 40.917705,
-                        "lng": -73.700169
+                }
+            },
+            {
+                "formatted_address": "Italy",
+                "geometry": {
+                    "bounds": {
+                        "northeast": {
+                            "lat": 47.092,
+                            "lng": 18.7975999
+                        },
+                        "southwest": {
+                            "lat": 35.4897,
+                            "lng": 6.6267201
+                        }
                     },
-                    "southwest": {
-                        "lat": 40.476578,
-                        "lng": -74.258843
+                    "location": {
+                        "lat": 41.87194,
+                        "lng": 12.56738
+                    },
+                    "location_type": "APPROXIMATE",
+                    "viewport": {
+                        "northeast": {
+                            "lat": 47.092,
+                            "lng": 18.7975999
+                        },
+                        "southwest": {
+                            "lat": 35.4897,
+                            "lng": 6.6267201
+                        }
                     }
                 }
             }
-        }
+        ],
+        [
+            {
+                "formatted_address": "London, UK",
+                "geometry": {
+                    "bounds": {
+                        "northeast": {
+                            "lat": 51.6723432,
+                            "lng": 0.148271
+                        },
+                        "southwest": {
+                            "lat": 51.38494009999999,
+                            "lng": -0.3514683
+                        }
+                    },
+                    "location": {
+                        "lat": 51.5072178,
+                        "lng": -0.1275862
+                    },
+                    "location_type": "APPROXIMATE",
+                    "viewport": {
+                        "northeast": {
+                            "lat": 51.8822255,
+                            "lng": 0.148271
+                        },
+                        "southwest": {
+                            "lat": 51.38494009999999,
+                            "lng": -0.4149317
+                        }
+                    }
+                }
+            },
+            {
+                "formatted_address": "London, UK",
+                "geometry": {
+                    "bounds": {
+                        "northeast": {
+                            "lat": 51.6723432,
+                            "lng": 0.148271
+                        },
+                        "southwest": {
+                            "lat": 51.38494009999999,
+                            "lng": -0.3514683
+                        }
+                    },
+                    "location": {
+                        "lat": 51.5072178,
+                        "lng": -0.1275862
+                    },
+                    "location_type": "APPROXIMATE",
+                    "viewport": {
+                        "northeast": {
+                            "lat": 51.8822255,
+                            "lng": 0.148271
+                        },
+                        "southwest": {
+                            "lat": 51.38494009999999,
+                            "lng": -0.4149317
+                        }
+                    }
+                }
+            }
+        ]
     ]
 }
 ```

--- a/fixtures/london_expected.json
+++ b/fixtures/london_expected.json
@@ -1,32 +1,34 @@
-[
-	{
-		"formatted_address": "London, UK",
-		"geometry": {
-			"bounds": {
-				"northeast": {
-					"lat": 51.6723432,
-					"lng": 0.148271
+[	
+	[
+		{
+			"formatted_address": "London, UK",
+			"geometry": {
+				"bounds": {
+					"northeast": {
+						"lat": 51.6723432,
+						"lng": 0.148271
+					},
+					"southwest": {
+						"lat": 51.38494009999999,
+						"lng": -0.3514683
+					}
 				},
-				"southwest": {
-					"lat": 51.38494009999999,
-					"lng": -0.3514683
-				}
-			},
-			"location": {
-				"lat": 51.5072178,
-				"lng": -0.1275862
-			},
-			"location_type": "APPROXIMATE",
-			"viewport": {
-				"northeast": {
-					"lat": 51.8822255,
-					"lng": 0.148271
+				"location": {
+					"lat": 51.5072178,
+					"lng": -0.1275862
 				},
-				"southwest": {
-					"lat": 51.38494009999999,
-					"lng": -0.4149317
+				"location_type": "APPROXIMATE",
+				"viewport": {
+					"northeast": {
+						"lat": 51.8822255,
+						"lng": 0.148271
+					},
+					"southwest": {
+						"lat": 51.38494009999999,
+						"lng": -0.4149317
+					}
 				}
 			}
 		}
-	}
+	]
 ]

--- a/src/geocoding.py
+++ b/src/geocoding.py
@@ -11,20 +11,21 @@ class GeocodingController:
     async def get_coordinates(self, locations: list[list[str]]):
         async with httpx.AsyncClient() as client:
             return await asyncio.gather(
-                *[self.geocoding_request(client, location) for location in locations]
+                *[self.geocode_location(client, location) for location in locations]
             )
 
-    async def geocoding_request(self, client: httpx.AsyncClient, location: list[str]):
+    async def geocode_location(self, client: httpx.AsyncClient, location: list[str]):
         if not location:
             return {}
 
-        requests = [
-            client.get(self._url, params={"key": self._api_key, "address": name})
-            for name in location
-        ]
+        requests = [self.geocoding_request(client, name) for name in location]
         responses = await asyncio.gather(*requests, return_exceptions=True)
 
         return [self.build_result(response) for response in responses]
+
+    def geocoding_request(self, client: httpx.AsyncClient, location_name: str):
+        params = {"key": self._api_key, "address": location_name}
+        return client.get(self._url, params=params)
 
     def build_result(self, response: httpx.Response | Exception):
         if isinstance(response, Exception):

--- a/src/geocoding.py
+++ b/src/geocoding.py
@@ -8,26 +8,34 @@ class GeocodingController:
     def __init__(self) -> None:
         self._url, self._api_key = load_url_and_api_key()
 
-    async def get_coordinates(self, locations: list[str]):
+    async def get_coordinates(self, locations: list[list[str]]):
         async with httpx.AsyncClient() as client:
             return await asyncio.gather(
                 *[self.geocoding_request(client, location) for location in locations]
             )
 
-    async def geocoding_request(self, client: httpx.AsyncClient, location: str):
+    async def geocoding_request(self, client: httpx.AsyncClient, location: list[str]):
         if not location:
             return {}
 
-        params = {"key": self._api_key, "address": location}
-        response = await client.get(self._url, params=params)
-        response.raise_for_status()
-        results = response.json()["results"]
+        requests = [
+            client.get(self._url, params={"key": self._api_key, "address": name})
+            for name in location
+        ]
+        responses = await asyncio.gather(*requests, return_exceptions=True)
 
-        if not results:
+        return [self.build_result(response) for response in responses]
+
+    def build_result(self, response: httpx.Response | Exception):
+        if isinstance(response, Exception):
             return {}
 
-        result = results[0]
+        data = response.json().get("results", [])
+        if not data:
+            return {}
+
+        data = data[0]
         return {
-            "formatted_address": result["formatted_address"],
-            "geometry": result["geometry"],
+            "formatted_address": data.get("formatted_address"),
+            "geometry": data.get("geometry"),
         }

--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,7 @@ app.add_middleware(
 
 
 class GeocodeRequest(BaseModel):
-    locations: list[str]
+    locations: list[list[str]]
 
 
 @app.post("/encode")

--- a/tests/test_geocoding_controller.py
+++ b/tests/test_geocoding_controller.py
@@ -24,7 +24,7 @@ async def test_get_coordinates_success(mock_http_get, mock_load_url_and_api_key)
     mock_http_get.return_value = mock_response
 
     controller = GeocodingController()
-    result = await controller.get_coordinates(["london"])
+    result = await controller.get_coordinates([["london"]])
 
     assert result == london_expected
     mock_http_get.assert_called_once_with(
@@ -46,7 +46,7 @@ async def test_get_coordinates_empty_results(mock_http_get, mock_load_url_and_ap
 
     controller = GeocodingController()
 
-    result = await controller.get_coordinates(["The Void"])
+    result = await controller.get_coordinates([["The Void"]])
 
-    expected = [{}]
+    expected = [[{}]]
     assert result == expected


### PR DESCRIPTION
https://qtravel.atlassian.net/browse/ITAI-3775

From now on `encode` endpoint accepts a list of location names for each location.
For every name the coordinates are returned, if found by google api.

**how to test**
request:
```
{
    "locations": [["Belek", "Belka"]] 
}
```
Expected result: coordinates for `Belek`, no results for `Belka` which is a pdn2 lemmatization.