### PR TITLE
ITAI-3848 - cache management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 GEOCODING_URL=https://maps.googleapis.com/maps/api/geocode/json
 GEOCODING_API_KEY=xxx
+
+REDIS_HOST=redis
+REDIS_PORT=6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - .:/app
     networks:
-      - redis-net
+      - geocoding_net
     depends_on:
       - redis
 
@@ -19,9 +19,10 @@ services:
     ports:
       - "6379:6379"
     networks:
-      - redis-net
+      - geocoding_net
     volumes:
-      - cache:/data
+      - geocoding-cache:/data
+    command: ["redis-server", "--appendonly", "no", "--maxmemory", "2gb", "--maxmemory-policy", "allkeys-lfu"]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 30s
@@ -29,8 +30,8 @@ services:
       retries: 3
 
 networks:
-  redis-net:
-    name: redis-net
+  geocoding_net:
+    name: geocoding_net
 
 volumes:
-  cache:
+  geocoding-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,28 @@ services:
       - .env
     volumes:
       - .:/app
+    networks:
+      - redis-net
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    networks:
+      - redis-net
+    volumes:
+      - cache:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+networks:
+  redis-net:
+    name: redis-net
+
+volumes:
+  cache:

--- a/fixtures/london_expected.json
+++ b/fixtures/london_expected.json
@@ -28,7 +28,8 @@
 						"lng": -0.4149317
 					}
 				}
-			}
+			},
+			"source": "Geocoding API"
 		}
 	]
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi==0.115.12
-uvicorn==0.34.2
 httpx==0.28.1
 pytest==8.3.5
 pytest-asyncio==0.26.0
+redis==6.4.0
+uvicorn==0.34.2

--- a/src/cache.py
+++ b/src/cache.py
@@ -1,0 +1,45 @@
+import json
+import os
+from functools import wraps
+
+import httpx
+import redis
+
+
+class RedisClient:
+    def __init__(self):
+        host = os.environ.get("REDIS_HOST", "redis")
+        port = os.environ.get("REDIS_PORT", 6379)
+        pool = redis.ConnectionPool(host=host, port=port)
+        self.connection = redis.Redis(connection_pool=pool)
+        self.connection.ping()
+
+
+def cache_response(redis_client: redis.Redis, namespace: str = "geolocations"):
+    """
+    Caching decorator. Attempts to retrieve the data from redis, otherwise calls the function and caches the response.
+
+    namespace: Namespace for cache keys in Redis.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            location = kwargs.get("location_name")
+            if location:
+                cache_key = f"{namespace}:{location}"
+                cached_value = redis_client.get(cache_key)
+                if cached_value:
+                    return json.loads(cached_value)
+
+            response: httpx.Response
+            response = await func(*args, **kwargs)
+
+            if response.json().get("results"):
+                redis_client.set(cache_key, response.text)
+
+            return response
+
+        return wrapper
+
+    return decorator

--- a/src/geocoding.py
+++ b/src/geocoding.py
@@ -1,12 +1,18 @@
-import httpx
 import asyncio
+import logging
 
+import httpx
+
+from src.cache import RedisClient, cache_response
 from src.config import load_url_and_api_key
+
+redis_client = RedisClient().connection
 
 
 class GeocodingController:
     def __init__(self) -> None:
         self._url, self._api_key = load_url_and_api_key()
+        self.logger = logging.getLogger("uvicorn.error")
 
     async def get_coordinates(self, locations: list[list[str]]):
         async with httpx.AsyncClient() as client:
@@ -18,25 +24,44 @@ class GeocodingController:
         if not location:
             return {}
 
-        requests = [self.geocoding_request(client, name) for name in location]
+        requests = [
+            self.geocoding_request(client=client, location_name=name)
+            for name in location
+        ]
         responses = await asyncio.gather(*requests, return_exceptions=True)
 
         return [self.build_result(response) for response in responses]
 
+    @cache_response(redis_client=redis_client)
     def geocoding_request(self, client: httpx.AsyncClient, location_name: str):
         params = {"key": self._api_key, "address": location_name}
         return client.get(self._url, params=params)
 
-    def build_result(self, response: httpx.Response | Exception):
-        if isinstance(response, Exception):
-            return {}
+    def build_result(self, response: httpx.Response | dict):
+        """Builds a hash with results from given response.
 
-        data = response.json().get("results", [])
+        Args:
+            response (httpx.Response | Exception | dict): response might be one of 2 types
+                - http.Response when data provided from google API
+                - python dictionary when data provided from cache
+
+        Returns:
+            dict: a dictionary with brief address info and it's location
+        """
+        if isinstance(response, httpx.Response):
+            response = response.json()
+            source = "Geocoding API"
+        else:
+            source = "Redis cache"
+
+        data = response.get("results", [])
         if not data:
+            self.logger.error(response)
             return {}
 
         data = data[0]
         return {
             "formatted_address": data.get("formatted_address"),
             "geometry": data.get("geometry"),
+            "source": source,
         }

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
-from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 
 from src.geocoding import GeocodingController
 

--- a/tests/test_geocoding_controller.py
+++ b/tests/test_geocoding_controller.py
@@ -1,6 +1,7 @@
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
+import httpx
 import pytest
 
 from src.geocoding import GeocodingController
@@ -13,41 +14,83 @@ with open("fixtures/london_response.json", "r") as response, open(
 
 
 @pytest.mark.asyncio
+@patch("src.geocoding.redis_client.get")
+@patch("src.geocoding.redis_client.set")
 @patch(
     "src.geocoding.load_url_and_api_key",
     return_value=("http://mock-url", "mock-api-key"),
 )
 @patch("httpx.AsyncClient.get")
-async def test_get_coordinates_success(mock_http_get, mock_load_url_and_api_key):
-    mock_response = MagicMock()
-    mock_response.raise_for_status.return_value = None
-    mock_response.json.return_value = london_fixture
+async def test_get_coordinates_google_api_hit(
+    mock_http_get, mock_load_url_and_api_key, mock_redis_set, mock_redis_get
+):
+    mock_response = httpx.Response(
+        status_code=200,
+        content=json.dumps(london_fixture),
+        request=httpx.Request("GET", "http://mock-url"),
+    )
     mock_http_get.return_value = mock_response
+    mock_redis_get.return_value = None
 
     controller = GeocodingController()
     result = await controller.get_coordinates([["london"]])
 
-    assert result == london_expected
     mock_http_get.assert_called_once_with(
         "http://mock-url", params={"key": "mock-api-key", "address": "london"}
     )
+    mock_redis_get.assert_called()
+    mock_redis_set.assert_called()
+    assert result == london_expected
 
 
 @pytest.mark.asyncio
+@patch("src.geocoding.redis_client.get")
+@patch("src.geocoding.redis_client.set")
 @patch(
     "src.geocoding.load_url_and_api_key",
     return_value=("http://mock-url", "mock-api-key"),
 )
 @patch("httpx.AsyncClient.get")
-async def test_get_coordinates_empty_results(mock_http_get, mock_load_url_and_api_key):
-    mock_response = MagicMock()
-    mock_response.raise_for_status.return_value = None
-    mock_response.json.return_value = {"results": []}
-    mock_http_get.return_value = mock_response
+async def test_get_coordinates_cache_hit(
+    mock_http_get, mock_load_url_and_api_key, mock_redis_set, mock_redis_get
+):
+    mock_redis_get.return_value = json.dumps(london_fixture)
 
     controller = GeocodingController()
+    result = await controller.get_coordinates([["london"]])
 
+    mock_http_get.assert_not_called()
+    mock_redis_get.assert_called()
+    mock_redis_set.assert_not_called()
+
+    london_expected[0][0]["source"] = "Redis cache"
+    assert result == london_expected
+
+
+@pytest.mark.asyncio
+@patch("src.geocoding.redis_client.get")
+@patch("src.geocoding.redis_client.set")
+@patch(
+    "src.geocoding.load_url_and_api_key",
+    return_value=("http://mock-url", "mock-api-key"),
+)
+@patch("httpx.AsyncClient.get")
+async def test_get_coordinates_empty_results(
+    mock_http_get, mock_load_url_and_api_key, mock_redis_set, mock_redis_get
+):
+    mock_response = httpx.Response(
+        status_code=200,
+        content=json.dumps({"results": []}),
+        request=httpx.Request("GET", "http://mock-url"),
+    )
+    mock_http_get.return_value = mock_response
+    mock_redis_get.return_value = None
+
+    controller = GeocodingController()
     result = await controller.get_coordinates([["The Void"]])
+
+    mock_redis_get.assert_called()
+    mock_redis_set.assert_not_called()
 
     expected = [[{}]]
     assert result == expected

--- a/tests/test_geocoding_controller.py
+++ b/tests/test_geocoding_controller.py
@@ -1,6 +1,7 @@
 import json
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 from src.geocoding import GeocodingController
 


### PR DESCRIPTION
https://qtravel.atlassian.net/browse/ITAI-3848

## Description

Adds redis cache to docker compose stack.
For every location name in the request check for cache hit.
After successful google api geocoding request, update the cache.

Also, adds isort for imports sorting.

## How to test
- run one query two times, observe the `source` field in the response, it indicates whether the response came from cache or google api